### PR TITLE
Show day of the week

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,26 @@ var urls = {
     }
 }
 
+function toDateString(when) {
+  const date = new Date(when * 1000);
+  try {
+    return new Intl.DateTimeFormat(navigator.languages, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      weekday: "short",
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    }).format(date);
+  } catch (e) {
+    return date.toLocaleString();
+  }
+}
+
 function addItem({era, when, user, message, channel}) {
-    const when_str = (new Date(when * 1000)).toLocaleString();
+    const when_str = toDateString(when)
 
     const item = DOM.create("li");
     if (channel.startsWith("#")) {
@@ -136,8 +154,8 @@ function dataLoaded(xhr, era, user, start, end, info) {
     });
     info.results.map(addItem);
 
-    const start_str = (new Date(start * 1000)).toLocaleString();
-    const end_str = (new Date(end * 1000)).toLocaleString();
+    const start_str = toDateString(start);
+    const end_str = toDateString(end);
     $HEADER_TITLE.textContent = `Updates for ${user}`;
     $HEADER_DATE.textContent = `from ${start_str} to ${end_str}`;
 }


### PR DESCRIPTION
For meeting purpose, having day of the week shown there helps where to start looking
Added code with `Intl.DateTimeFormat`, while keeping the previous code as fallback in case Intl API is not available.