### PR TITLE
More regexps

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,12 +17,25 @@
     <hr>
     <button onclick='this.toggled = !this.toggled; document.getElementById("abouttext").style = "visibility:" + (this.toggled ? "block":"hidden")'>About</button>
     <div id="abouttext" style="visibility:hidden">
-    This is a simple mechanism for recording timestamped messages. Add a message by saying "confession: &lt;whatever&gt;" in an IRC channel that contains the 'confession' bot. All messages are stored in <a href="https://github.com/mrgiggles/histoire">https://github.com/mrgiggles/histoire</a>. Note that this message store, and the whole mechanism, is 100% completely public.
+    This is a simple mechanism for recording timestamped messages. Add a message by saying
+    "confession: &lt;whatever&gt;" in an IRC channel that contains the 'confession' bot. All
+    messages are stored in
+    <a href="https://github.com/mrgiggles/histoire">https://github.com/mrgiggles/histoire</a>.
+    Note that this message store, and the whole mechanism, is 100% completely
+    public.
       <p>
-        If you wish to modify any existing messages, you can <a href='https://github.com/mrgiggles/histoire/tree/master/users/sfink'>submit a PR</a> to the github repository. Currently, you will also need to ping sfink on IRC or email sfink@mozilla.com to have updates merged, but I plan to enable one of the many auto-merge bots to just blindly accept anything (once I figure out which one to use.) The IRC bot uses a special append-only merge driver, so hopefully will not get conflicts unless you delete files or something.
+        If you wish to modify any existing messages, you can
+        <a href='https://github.com/mrgiggles/histoire/tree/master/users/sfink'>submit a PR</a> to
+        the github repository. Currently, you will also need to ping sfink on IRC or email
+        sfink@mozilla.com to have updates merged, but I plan to enable one of the many auto-merge
+        bots to just blindly accept anything (once I figure out which one to use.) The IRC bot uses
+        a special append-only merge driver, so hopefully will not get conflicts unless you delete
+        files or something.
       </p>
       <p>
-        Feel free to file issues on the github repo. mrgiggles will feel free to ignore them. At some point I'll figure out how to forward his mail to me so I can see them.
+        Feel free to file issues on the <a href="https://github.com/mrgiggles/histoire">github
+        repo</a>. mrgiggles will feel free to ignore them. At some point I'll figure out how to
+        forward his mail to me so I can see them.
       </p>
     </div>
   </body>


### PR DESCRIPTION
Many changes here, see commit by commit:

1. wrap html text in text editor
2. add a way to match `A#B` in messages, where A is a known github repository name (hardcoded in a map at the top), and B a pull request number. (Ideally we'd have a way to distinguish pull request id and issue id, or we'd do a XHR request to the issue number and if it fails we'd conclude it's a pull request, but i opted for something simple) I've included `histoire`, `cranelift` and `binjs-ref` so far, it's really easy to add more of them.
3. add a test mode accessible with `?test=1`, to test regexp rendering. This mostly moves code around, and hardcodes entries for testing, which is nice.